### PR TITLE
Set green home page background

### DIFF
--- a/src/pages/IndexPage/IndexPage.tsx
+++ b/src/pages/IndexPage/IndexPage.tsx
@@ -8,7 +8,8 @@ import tonSvg from './ton.svg';
 
 export const IndexPage: FC = () => {
   return (
-    <Page back={false}>
+    <div style={{ backgroundColor: 'green', minHeight: '100vh' }}>
+      <Page back={false}>
       <List>
         <Section
           header="Features"
@@ -38,6 +39,7 @@ export const IndexPage: FC = () => {
           </Link>
         </Section>
       </List>
-    </Page>
+      </Page>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary
- set main page background to green

## Testing
- `npm run build`
- `npm run lint` *(fails: requires type information)*

------
https://chatgpt.com/codex/tasks/task_e_68737f06812c832897938de4bbcaf3b9