### PR TITLE
Add counter to main page

### DIFF
--- a/src/pages/IndexPage/IndexPage.tsx
+++ b/src/pages/IndexPage/IndexPage.tsx
@@ -1,5 +1,5 @@
-import { Section, Cell, Image, List } from '@telegram-apps/telegram-ui';
-import type { FC } from 'react';
+import { Section, Cell, Image, List, Button } from '@telegram-apps/telegram-ui';
+import { FC, useState } from 'react';
 
 import { Link } from '@/components/Link/Link.tsx';
 import { Page } from '@/components/Page.tsx';
@@ -7,10 +7,23 @@ import { Page } from '@/components/Page.tsx';
 import tonSvg from './ton.svg';
 
 export const IndexPage: FC = () => {
+  const [count, setCount] = useState(0);
+
   return (
     <div style={{ backgroundColor: 'green', minHeight: '100vh' }}>
       <Page back={false}>
       <List>
+        <Section header="Counter">
+          <Cell
+            after={(
+              <Button size="s" onClick={() => setCount((c) => c + 1)}>
+                +1
+              </Button>
+            )}
+          >
+            {count}
+          </Cell>
+        </Section>
         <Section
           header="Features"
           footer="You can use these pages to learn more about features, provided by Telegram Mini Apps and other useful projects"


### PR DESCRIPTION
## Summary
- add simple counter to home screen

## Testing
- `npm run lint` *(fails: requires parser options for @typescript-eslint)*

------
https://chatgpt.com/codex/tasks/task_e_6873814b3a808328a65dab21c02c4f9f